### PR TITLE
feat: extract ETCCore, add tests, wire UI, and add magnitude sliders

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,89 @@ A preliminary Exposure Time Calculator for JASMINE.
 ![screenshot](docs/figs/screenshot.png)
 
 [etc]: https://jasmine-mission.github.io/jasmine-etc/
+
+## Quick Start
+
+- Open the published page: https://jasmine-mission.github.io/jasmine-etc/
+- Or run locally (requires Node.js):
+
+  ```bash
+  node scripts/serve.js
+  # then open http://localhost:8080/ (defaults to /etc/index.html)
+  ```
+
+## Overview
+
+- Static, CDN-based web app (no build step) using:
+  - Vue 2 (Options API) for UI state
+  - Plotly for graphs (S/N and positional accuracy vs magnitude)
+  - A small, framework-free core module for physics/calculations
+- The app is preliminary and parameters/coefficients are subject to change.
+
+## Core Module (ETCCore)
+
+- Location: `etc/js/core.js`
+- Format: UMD (browser global `window.ETCCore`, Node `module.exports`)
+- Contains pure functions that implement the physics model used by the UI.
+
+Examples:
+
+```js
+// Browser (CDN Vue/Plotly, local ETCCore):
+// <script src="js/core.js"></script>
+const Hw = ETCCore.hwFromJ(J, JH);
+const params = ETCCore.defaultParams();
+const snr = ETCCore.get_SNR(Hw, params);
+```
+
+```js
+// Node (tests/scripts):
+const core = require('./etc/js/core.js');
+const p = core.defaultParams();
+const Hw = core.hwFromJ(p.J, p.JH);
+console.log(core.get_SNR(Hw, p));
+```
+
+Key functions (selection): `hwFromJ`, `throughput`, `pixelScale`, `totalSigma`, `get_flux`,
+`get_photon_array`, `get_total_photon`, `get_noise`, `get_SNR`, `get_sigexp`, `peak_photon`.
+
+## UI Notes
+
+- The UI delegates all physics calculations to `ETCCore`.
+- Advanced panel includes additional controls:
+  - Backgrounds, transmittances, detector QE, ADC bits
+  - Magnitude range for the graph (Hw x-axis):
+    - Min slider: [5, 12], step 0.1
+    - Max slider: [13, 20], step 0.1
+    - Step input: sampling step in mag (default 0.5, capped to ≤60 points)
+- Simulated PSF image is drawn on a 15×15 canvas grid with optional asinh scaling on hover.
+
+## Tests
+
+- Minimal Node-based test harness (no external runner):
+
+  ```bash
+  node tests/run-tests.js
+  ```
+
+- What it checks (examples):
+  - Pixel scale sanity
+  - SNR increases with exposure time
+  - σexp decreases with exposure time
+  - Peak photon increases for sharper PSF
+  - Total photon increases with throughput
+  - Photon array sum does not exceed the ideal total photons
+
+## Local Development
+
+- Files of interest:
+  - `etc/index.html` — main page
+  - `etc/css/main.css` — styles (including custom square sliders under Advanced)
+  - `etc/js/jasmine-etc.js` — UI glue, rendering, and Plotly integration
+  - `etc/js/core.js` — pure calculation module (ETCCore)
+  - `scripts/serve.js` — tiny static server for local checks
+  - `tests/` — simple Node tests for core functions
+
+## License
+
+MIT — see `LICENSE`.

--- a/etc/css/main.css
+++ b/etc/css/main.css
@@ -146,3 +146,64 @@ input[data-invalid] {
 #etc ul {
   padding-left: 1.0em;
 }
+
+/* Range slider styling for magnitude controls */
+.range {
+  -webkit-appearance: none;
+  appearance: none;
+  margin: 0;
+  /* match other inputs: border 2px, square corners, similar height */
+  --h: 19px;
+  --thumb-w: 0px;
+  --thumb-h: calc(var(--h) - 6px);
+  height: var(--h);
+  border: 2px solid lightgray;
+  border-radius: 0;
+  background:
+    linear-gradient(#eee, #eee) 0/var(--sx, 0%) 100% no-repeat,
+    #fff;
+  /* compute filled size: --sx as percent of track */
+  --min: 0;
+  --max: 100;
+  --val: 0;
+  --sx: calc((var(--val) - var(--min)) * 100% / (var(--max) - var(--min)));
+}
+
+/* WebKit */
+.range::-webkit-slider-runnable-track {
+  -webkit-appearance: none;
+  background: transparent;
+  border: none;
+  height: 100%;
+}
+.range::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: var(--thumb-w);
+  height: var(--thumb-h);
+  background: #666;
+  border: none;
+  /* center thumb vertically within outlined track */
+  margin-top: calc((var(--h) - var(--thumb-h)) / 2 - 1px);
+  cursor: pointer;
+}
+
+/* Firefox */
+.range::-moz-range-track {
+  height: var(--h);
+  background: #fff;
+  border: 2px solid lightgray;
+  border-radius: 0;
+}
+.range::-moz-range-progress {
+  height: var(--h);
+  background: #eee;
+  border: none;
+  border-radius: 0;
+}
+.range::-moz-range-thumb {
+  width: var(--thumb-w);
+  height: var(--thumb-h);
+  background: #666;
+  border: none;
+  cursor: pointer;
+}

--- a/etc/index.html
+++ b/etc/index.html
@@ -127,13 +127,15 @@
             <span class="unit">bit</span>
 
             <label>Magnitude min</label>
-            <input type="range" v-model.number="mag_min"
-                min="5" max="12" step="0.1" />
+            <input type="range" class="range" v-model.number="mag_min"
+                min="5" max="12" step="0.1"
+                :style="{'--min': 5, '--max': 12, '--val': mag_min}" />
             <span class="unit">{{ mag_min.toFixed(1) }} mag</span>
 
             <label>Magnitude max</label>
-            <input type="range" v-model.number="mag_max"
-                min="13" max="20" step="0.1" />
+            <input type="range" class="range" v-model.number="mag_max"
+                min="13" max="20" step="0.1"
+                :style="{'--min': 13, '--max': 20, '--val': mag_max}" />
             <span class="unit">{{ mag_max.toFixed(1) }} mag</span>
 
             <label>Magnitude step</label>

--- a/etc/index.html
+++ b/etc/index.html
@@ -24,8 +24,8 @@
   <meta name='viewport' content='width=device-width, initial-scale=1'>
   <link rel='stylesheet' type='text/css' media='screen' href='css/main.css'>
   <script src='https://cdn.jsdelivr.net/npm/vue@2.6.11/dist/vue.js'></script>
-  <script src="https://cdn.jsdelivr.net/npm/mathjs@11.11.2/lib/browser/math.min.js"></script>
   <script src="https://cdn.plot.ly/plotly-2.26.0.min.js" charset="utf-8"></script>
+  <script src='js/core.js'></script>
 </head>
 <body>
   <h1 id="title">

--- a/etc/index.html
+++ b/etc/index.html
@@ -125,6 +125,21 @@
             <etc-input v-model="adcbit" precision="0"
                 step="1" min="2" max="18"></etc-input>
             <span class="unit">bit</span>
+
+            <label>Magnitude min</label>
+            <etc-input v-model="mag_min" precision="2"
+                min="-5.0" max="40.0"></etc-input>
+            <span class="unit">mag</span>
+
+            <label>Magnitude max</label>
+            <etc-input v-model="mag_max" precision="2"
+                min="-5.0" max="40.0"></etc-input>
+            <span class="unit">mag</span>
+
+            <label>Magnitude step</label>
+            <etc-input v-model="mag_step" precision="2"
+                min="0.01" max="10.0"></etc-input>
+            <span class="unit">mag</span>
           </div>
         </fieldset>
       </form>

--- a/etc/index.html
+++ b/etc/index.html
@@ -129,12 +129,12 @@
             <label>Magnitude min</label>
             <input type="range" v-model.number="mag_min"
                 min="5" max="12" step="0.1" />
-            <span class="unit">mag</span>
+            <span class="unit">{{ mag_min.toFixed(1) }} mag</span>
 
             <label>Magnitude max</label>
             <input type="range" v-model.number="mag_max"
                 min="13" max="20" step="0.1" />
-            <span class="unit">mag</span>
+            <span class="unit">{{ mag_max.toFixed(1) }} mag</span>
 
             <label>Magnitude step</label>
             <etc-input v-model="mag_step" precision="2"

--- a/etc/index.html
+++ b/etc/index.html
@@ -127,13 +127,13 @@
             <span class="unit">bit</span>
 
             <label>Magnitude min</label>
-            <etc-input v-model="mag_min" precision="2"
-                min="-5.0" max="40.0"></etc-input>
+            <input type="range" v-model.number="mag_min"
+                min="5" max="12" step="0.1" />
             <span class="unit">mag</span>
 
             <label>Magnitude max</label>
-            <etc-input v-model="mag_max" precision="2"
-                min="-5.0" max="40.0"></etc-input>
+            <input type="range" v-model.number="mag_max"
+                min="13" max="20" step="0.1" />
             <span class="unit">mag</span>
 
             <label>Magnitude step</label>

--- a/etc/js/core.js
+++ b/etc/js/core.js
@@ -2,13 +2,13 @@
  JASMINE ETC core calculation module
  - Pure functions mirroring the logic in etc/js/jasmine-etc.js
  - No dependency on Vue or math.js (implements erf internally)
- - UMD-style export: window.JETCCore (browser) or module.exports (Node)
+ - UMD-style export: window.ETCCore (browser) or module.exports (Node)
 */
 (function (root, factory) {
   if (typeof module === 'object' && typeof module.exports === 'object') {
     module.exports = factory();
   } else {
-    root.JETCCore = factory();
+    root.ETCCore = factory();
   }
 })(typeof self !== 'undefined' ? self : this, function () {
   'use strict';
@@ -235,4 +235,3 @@
     defaultParams: defaultParams,
   };
 });
-

--- a/etc/js/core.js
+++ b/etc/js/core.js
@@ -28,7 +28,8 @@
     return sign * y;
   }
 
-  // NOTE: Matches existing implementation: parameter s is used as (variance-like) in denominator sqrt(2*s)
+  // Cumulative distribution function (CDF) for a normal distribution with mean 0 and variance s.
+  // Parameter s is the variance (i.e., standard deviation squared) of the distribution.
   function cdf(x, s) {
     return 0.5 + 0.5 * erf(x / Math.sqrt(2 * s));
   }

--- a/etc/js/core.js
+++ b/etc/js/core.js
@@ -17,19 +17,20 @@
   function erf(x) {
     var sign = x < 0 ? -1 : 1;
     x = Math.abs(x);
-    var a1 = 0.254829592,
-      a2 = -0.284496736,
-      a3 = 1.421413741,
-      a4 = -1.453152027,
-      a5 = 1.061405429,
-      p = 0.3275911;
+    var a1 = 0.254829592;
+    var a2 = -0.284496736;
+    var a3 = 1.421413741;
+    var a4 = -1.453152027;
+    var a5 = 1.061405429;
+    var p = 0.3275911;
     var t = 1.0 / (1.0 + p * x);
-    var y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
+    var y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1)
+      * t * Math.exp(-x * x);
     return sign * y;
   }
 
-  // Cumulative distribution function (CDF) for a normal distribution with mean 0 and variance s.
-  // Parameter s is the variance (i.e., standard deviation squared) of the distribution.
+  // Cumulative distribution function (CDF) for a normal distribution with
+  // mean 0 and variance s. Parameter s is the variance of the distribution.
   function cdf(x, s) {
     return 0.5 + 0.5 * erf(x / Math.sqrt(2 * s));
   }
@@ -41,7 +42,8 @@
 
   function throughput(params) {
     return (
-      params.Tr_filter * params.Tr_mirror * params.qe_detector * (1 - params.M2_fraction)
+      params.Tr_filter * params.Tr_mirror
+        * params.qe_detector * (1 - params.M2_fraction)
     );
   }
 
@@ -55,6 +57,16 @@
 
   // Photon flux for magnitude Hw (kept identical constant)
   function get_flux(Hw) {
+    /**
+     * The Hw-band zeromag photon rate is tentatively converted from
+     * the J-band zeromag photon rate assuming
+     *
+     *   - the primary mirror diameter = 36 cm
+     *   - the filter range = 1.1-1.6 um
+     *
+     * The J-band zeromag photon rate is obtained from
+     *   - https://www.astronomy.ohio-state.edu/martini.10/usefuldata.html
+     */
     return 9.82759297e+08 * Math.pow(10, -0.4 * Hw);
   }
 
@@ -159,16 +171,21 @@
   }
 
   function get_sigexp(Hw, params) {
-    var thr0 = typeof params.throughput0 === 'number' ? params.throughput0 : throughput(params);
-    var exp0 = typeof params.exptime0 === 'number' ? params.exptime0 : params.exptime;
+    var thr0 = typeof params.throughput0 === 'number'
+        ? params.throughput0 : throughput(params);
+    var exp0 = typeof params.exptime0 === 'number'
+        ? params.exptime0 : params.exptime;
     var N0 = thr0 * get_flux(12.5) * exp0;
     var Np = get_total_photon(Hw, params) / N0;
     var sig = totalSigma(params.sigpsf, params.sigace) * 1e3; // mas
     var sr = 2 * Math.pow(params.readout, 2);
     var sc = background(params) * params.exptime;
-    var S0 = (params.s0 != null ? params.s0 : 4.52e+4) * Math.pow(params.flat / 100, 2.0);
-    var S1 = (params.s1 != null ? params.s1 : 5.58e-5) * Math.pow(sig, 2);
-    var S2 = (params.s2 != null ? params.s2 : 6.82e-14) * (sr + sc) * Math.pow(sig, 4);
+    var S0 = (params.s0 != null ? params.s0 : 4.52e+4)
+        * Math.pow(params.flat / 100, 2.0);
+    var S1 = (params.s1 != null ? params.s1 : 5.58e-5)
+        * Math.pow(sig, 2);
+    var S2 = (params.s2 != null ? params.s2 : 6.82e-14)
+        * (sr + sc) * Math.pow(sig, 4);
     return Math.sqrt(S0 + S1 / Np + S2 / (Np * Np));
   }
 

--- a/etc/js/core.js
+++ b/etc/js/core.js
@@ -1,0 +1,238 @@
+/*
+ JASMINE ETC core calculation module
+ - Pure functions mirroring the logic in etc/js/jasmine-etc.js
+ - No dependency on Vue or math.js (implements erf internally)
+ - UMD-style export: window.JETCCore (browser) or module.exports (Node)
+*/
+(function (root, factory) {
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = factory();
+  } else {
+    root.JETCCore = factory();
+  }
+})(typeof self !== 'undefined' ? self : this, function () {
+  'use strict';
+
+  // Error function approximation (Abramowitz and Stegun, 7.1.26)
+  function erf(x) {
+    var sign = x < 0 ? -1 : 1;
+    x = Math.abs(x);
+    var a1 = 0.254829592,
+      a2 = -0.284496736,
+      a3 = 1.421413741,
+      a4 = -1.453152027,
+      a5 = 1.061405429,
+      p = 0.3275911;
+    var t = 1.0 / (1.0 + p * x);
+    var y = 1.0 - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * Math.exp(-x * x);
+    return sign * y;
+  }
+
+  // NOTE: Matches existing implementation: parameter s is used as (variance-like) in denominator sqrt(2*s)
+  function cdf(x, s) {
+    return 0.5 + 0.5 * erf(x / Math.sqrt(2 * s));
+  }
+
+  // Magnitude conversion J,JH -> Hw (kept identical to app formula)
+  function hwFromJ(J, JH) {
+    return J + (0.08 + (-0.15 + 0.01 * JH) * JH) * JH;
+  }
+
+  function throughput(params) {
+    return (
+      params.Tr_filter * params.Tr_mirror * params.qe_detector * (1 - params.M2_fraction)
+    );
+  }
+
+  function pixelScale(pxd, efl) {
+    return Math.atan2(pxd, efl) / Math.PI * 180.0 * 3600.0;
+  }
+
+  function totalSigma(sigpsf, sigace) {
+    return Math.sqrt(sigpsf * sigpsf + sigace * sigace);
+  }
+
+  // Photon flux for magnitude Hw (kept identical constant)
+  function get_flux(Hw) {
+    return 9.82759297e+08 * Math.pow(10, -0.4 * Hw);
+  }
+
+  function get_net_flux(Hw, params) {
+    return throughput(params) * get_flux(Hw);
+  }
+
+  function get_photon(Hw, params) {
+    return get_net_flux(Hw, params) * params.exptime;
+  }
+
+  function buildGrid(n) {
+    var a = new Array(n);
+    for (var i = 0; i < n; i++) a[i] = i - (n - 1) / 2;
+    return a;
+  }
+
+  function get_photon_array(Hw, params) {
+    var nx = params.nx || buildGrid(15);
+    var ny = params.ny || buildGrid(15);
+    var N = get_photon(Hw, params);
+    var sig = totalSigma(params.sigpsf, params.sigace);
+    var w = sig / pixelScale(params.pxd, params.efl);
+    var arr = new Array(ny.length);
+    for (var j = 0; j < ny.length; j++) {
+      arr[j] = new Array(nx.length);
+      var y = ny[j];
+      var fy = cdf(y + 0.5, w) - cdf(y - 0.5, w);
+      for (var i = 0; i < nx.length; i++) {
+        var x = nx[i];
+        var fx = cdf(x + 0.5, w) - cdf(x - 0.5, w);
+        arr[j][i] = N * fy * fx;
+      }
+    }
+    return arr;
+  }
+
+  function sum2d(a) {
+    var s = 0;
+    for (var j = 0; j < a.length; j++) {
+      for (var i = 0; i < a[j].length; i++) s += a[j][i];
+    }
+    return s;
+  }
+
+  function max2d(a) {
+    var m = -Infinity;
+    for (var j = 0; j < a.length; j++) {
+      for (var i = 0; i < a[j].length; i++) if (a[j][i] > m) m = a[j][i];
+    }
+    return m;
+  }
+
+  function get_total_photon(Hw, params) {
+    return sum2d(get_photon_array(Hw, params));
+  }
+
+  function get_flat_noise_from_array(arr, flatPercent) {
+    var fe = flatPercent / 100.0;
+    var s2 = 0.0;
+    for (var j = 0; j < arr.length; j++) {
+      for (var i = 0; i < arr[j].length; i++) {
+        var e = arr[j][i];
+        s2 += Math.pow(fe * e, 2);
+      }
+    }
+    return Math.sqrt(s2);
+  }
+
+  function gain(params) {
+    return params.margin * params.fullwell / Math.pow(2, params.adcbit);
+  }
+
+  function qw_noise(params) {
+    return gain(params) / Math.sqrt(12);
+  }
+
+  function background(params) {
+    return params.dark + params.stray + params.diffuse;
+  }
+
+  function pixel_area(params) {
+    var sig = totalSigma(params.sigpsf, params.sigace);
+    var scale = pixelScale(params.pxd, params.efl);
+    var sigpix = sig / scale;
+    var aper = 2 * Math.sqrt(8 * Math.LN2) * sigpix;
+    return 4 * Math.PI * aper * aper;
+  }
+
+  function get_noise(Hw, params) {
+    var arr = get_photon_array(Hw, params);
+    var s2 = 2 * Math.pow(params.readout, 2) * pixel_area(params);
+    var ne = background(params) * pixel_area(params) * params.exptime;
+    var se = sum2d(arr);
+    var fe = Math.pow(get_flat_noise_from_array(arr, params.flat), 2);
+    var qe = Math.pow(qw_noise(params), 2);
+    return Math.sqrt(s2 + ne + se + fe + qe);
+  }
+
+  function get_SNR(Hw, params) {
+    return get_total_photon(Hw, params) / get_noise(Hw, params);
+  }
+
+  function get_sigexp(Hw, params) {
+    var thr0 = typeof params.throughput0 === 'number' ? params.throughput0 : throughput(params);
+    var exp0 = typeof params.exptime0 === 'number' ? params.exptime0 : params.exptime;
+    var N0 = thr0 * get_flux(12.5) * exp0;
+    var Np = get_total_photon(Hw, params) / N0;
+    var sig = totalSigma(params.sigpsf, params.sigace) * 1e3; // mas
+    var sr = 2 * Math.pow(params.readout, 2);
+    var sc = background(params) * params.exptime;
+    var S0 = (params.s0 != null ? params.s0 : 4.52e+4) * Math.pow(params.flat / 100, 2.0);
+    var S1 = (params.s1 != null ? params.s1 : 5.58e-5) * Math.pow(sig, 2);
+    var S2 = (params.s2 != null ? params.s2 : 6.82e-14) * (sr + sc) * Math.pow(sig, 4);
+    return Math.sqrt(S0 + S1 / Np + S2 / (Np * Np));
+  }
+
+  function peak_photon(Hw, params) {
+    return max2d(get_photon_array(Hw, params));
+  }
+
+  function defaultParams() {
+    return {
+      // Source
+      J: 12.5,
+      JH: 0.0,
+      // Instrument
+      exptime: 12.5,
+      sigpsf: 286.5e-3,
+      sigace: 275.0e-3,
+      readout: 15.0,
+      dark: 31.0,
+      stray: 0.0,
+      diffuse: 0.0,
+      flat: 1.0,
+      adcbit: 14,
+      M2_fraction: 0.35,
+      Tr_filter: 0.9933,
+      Tr_mirror: 0.8258,
+      qe_detector: 0.7481,
+      // System
+      pxd: 1e-5,
+      efl: 4.3704,
+      fullwell: 1e5,
+      margin: 2.0,
+      // Coefficients
+      s0: 4.52e+4,
+      s1: 5.58e-5,
+      s2: 6.82e-14,
+      // Grid
+      nx: null,
+      ny: null,
+    };
+  }
+
+  return {
+    // helpers
+    erf: erf,
+    cdf: cdf,
+    hwFromJ: hwFromJ,
+    throughput: throughput,
+    pixelScale: pixelScale,
+    totalSigma: totalSigma,
+    // core physics
+    get_flux: get_flux,
+    get_net_flux: get_net_flux,
+    get_photon: get_photon,
+    get_photon_array: get_photon_array,
+    get_total_photon: get_total_photon,
+    get_noise: get_noise,
+    get_SNR: get_SNR,
+    get_sigexp: get_sigexp,
+    peak_photon: peak_photon,
+    // utilities
+    gain: gain,
+    qw_noise: qw_noise,
+    background: background,
+    pixel_area: pixel_area,
+    defaultParams: defaultParams,
+  };
+});
+

--- a/etc/js/jasmine-etc.js
+++ b/etc/js/jasmine-etc.js
@@ -81,7 +81,11 @@ let etc = new Vue({
 
     nx: Array(15).fill().map((e, i) => -7 + i),
     ny: Array(15).fill().map((e, i) => -7 + i),
-    mag_array: Array(15).fill().map((_,i)=>9.0+0.5*i),
+
+    // Magnitude range controls for the plot
+    mag_min: 9.0,
+    mag_max: 16.0,
+    mag_step: 0.5,
   },
 
   methods: {
@@ -180,6 +184,16 @@ let etc = new Vue({
 
     rgb_array: function() {
       return this.get_RGB_array(this.adu_array);
+    },
+
+    mag_array: function() {
+      const lo = Math.min(this.mag_min, this.mag_max);
+      const hi = Math.max(this.mag_min, this.mag_max);
+      const step = (this.mag_step > 0) ? this.mag_step : 0.5;
+      // Guard against too many points for performance
+      const maxPoints = 60;
+      const count = Math.max(2, Math.min(maxPoints, Math.floor((hi - lo) / step) + 1));
+      return Array(count).fill().map((_, i) => lo + i * step);
     },
 
     total_sigma: function() {

--- a/etc/js/jasmine-etc.js
+++ b/etc/js/jasmine-etc.js
@@ -85,8 +85,6 @@ let etc = new Vue({
   },
 
   methods: {
-    cdf: (x,s) => 0.5 + 0.5 * math.erf(x / Math.sqrt(2*s)),
-
     randn: () => {
       const logu = Math.sqrt(-2.0 * Math.log(1.0 - Math.random()));
       const cosv = Math.cos(2.0 * Math.PI * Math.random());
@@ -97,78 +95,7 @@ let etc = new Vue({
 
     asinh_scale: (e, M, m) => Math.asinh(e - m) / Math.asinh(M - m),
 
-    get_flux: function(Hw) {
-      /** convert Hw magnitude to photon
-       * the J-band photon flux in
-       *   - https://www.astronomy.ohio-state.edu/martini.10/usefuldata.html
-       * is tentatively used to calculate the Hw-band photon rate.
-       * convert to the photon rate in the Hw-band assuming
-       *   - the primary mirror diameter = 36 cm
-       *   - the filter range = 1.1-1.6 um
-       */
-      return 9.82759297e+08 * Math.pow(10, -0.4 * Hw);
-    },
-
-    get_net_flux: function(Hw) {
-      return this.throughput * this.get_flux(Hw);
-    },
-
-    get_sigexp: function(Hw) {
-      const Np = this.get_total_photon(Hw) / this.N0;
-      const sig = this.total_sigma * 1e3;
-      const sr = 2 * Math.pow(this.readout, 2);
-      const sc = this.background * this.exptime;
-
-      const S0 = this.s0 * Math.pow(this.flat/100, 2.0);
-      const S1 = this.s1 * Math.pow(sig, 2);
-      const S2 = this.s2 * (sr + sc) * Math.pow(sig, 4);
-
-      return Math.sqrt(S0 + S1 / Np + S2 / Np / Np);
-    },
-
-    get_photon: function(Hw) {
-      return this.get_net_flux(Hw) * this.exptime;
-    },
-
-    get_total_photon: function(Hw) {
-      const arr = this.get_photon_array(Hw);
-      return arr.reduce((s,e) => s + e.reduce((s,e) => s + e,0), 0);
-    },
-
-    get_flat_noise: function(Hw) {
-      const arr = this.get_photon_array(Hw);
-      const fe = this.flat / 100;
-      return Math.sqrt(arr.reduce(
-        (s,e) => s + e.reduce((s,e) => s + Math.pow(fe * e, 2), 0), 0));
-    },
-
-    get_noise: function(Hw) {
-      const s2 = 2 * Math.pow(this.readout, 2) * this.pixel_area;
-      const ne = this.background * this.pixel_area * this.exptime;
-      const se = this.get_total_photon(Hw);
-      const fe = Math.pow(this.get_flat_noise(Hw), 2);
-      const qe = Math.pow(this.qw_noise, 2);
-      return Math.sqrt(s2 + ne + se + fe + qe);
-    },
-
-    get_SNR: function(Hw) {
-      return this.get_total_photon(Hw) / this.get_noise(Hw);
-    },
-
-    get_photon_array: function(Hw) {
-      let array = [...Array(15)].map(e => Array(15).fill());
-
-      const N = this.get_photon(Hw);
-      const w = this.total_sigma / this.pixel_scale;
-      for (let [j, y] of this.ny.entries()) {
-        for (let [i, x] of this.nx.entries()) {
-          const fy = this.cdf(y + 0.5, w) - this.cdf(y - 0.5, w);
-          const fx = this.cdf(x + 0.5, w) - this.cdf(x - 0.5, w);
-          array[j][i] = N * fy * fx;
-        }
-      }
-      return array;
-    },
+    // UI-side noise and rendering helpers remain here
 
     add_noise: function(photon) {
       const rn = 2 * Math.pow(this.readout, 2);
@@ -223,7 +150,7 @@ let etc = new Vue({
     },
 
     N0: function() {
-      return this.throughput0 * this.get_flux(12.5) * this.exptime0;
+      return (this.throughput0 || ETCCore.throughput(this)) * ETCCore.get_flux(12.5) * (this.exptime0 || this.exptime);
     },
 
     fwhm: {
@@ -236,16 +163,15 @@ let etc = new Vue({
     },
 
     gain: function() {
-      return this.margin * this.fullwell / Math.pow(2, this.adcbit);
+      return ETCCore.gain(this);
     },
 
     throughput: function() {
-      return this.Tr_filter * this.Tr_mirror
-        * this.qe_detector * (1 - this.M2_fraction);
+      return ETCCore.throughput(this);
     },
 
     photon_array: function() {
-      return this.get_photon_array(this.Hw);
+      return ETCCore.get_photon_array(this.Hw, this);
     },
 
     adu_array: function() {
@@ -257,50 +183,48 @@ let etc = new Vue({
     },
 
     total_sigma: function() {
-      return Math.sqrt(this.sigpsf**2 + this.sigace**2);
+      return ETCCore.totalSigma(this.sigpsf, this.sigace);
     },
 
     total_photon: function() {
-      return this.get_total_photon(this.Hw);
+      return ETCCore.get_total_photon(this.Hw, this);
     },
 
     peak_photon: function() {
-      return Math.max(...this.photon_array.flat());
+      return ETCCore.peak_photon(this.Hw, this);
     },
 
     pixel_scale: function() {
-      return Math.atan2(this.pxd, this.efl) / Math.PI * 180.0 * 3600;
+      return ETCCore.pixelScale(this.pxd, this.efl);
     },
 
     pixel_area: function() {
-      const sigpix = this.total_sigma / this.pixel_scale;
-      const aper = 2 * Math.sqrt(8 * Math.LN2) * sigpix;
-      return 4 * Math.PI * aper * aper;
+      return ETCCore.pixel_area(this);
     },
 
     background: function() {
-      return this.dark + this.stray + this.diffuse;
+      return ETCCore.background(this);
     },
 
     qw_noise: function() {
-      return this.gain/Math.sqrt(12);
+      return ETCCore.qw_noise(this);
     },
 
     total_noise: function() {
-      return this.get_noise(this.Hw)
+      return ETCCore.get_noise(this.Hw, this);
     },
 
     sn_ratio: function() {
-      return this.get_SNR(this.Hw);
+      return ETCCore.get_SNR(this.Hw, this);
     },
 
     sig_exp: function() {
-      return this.get_sigexp(this.Hw);
+      return ETCCore.get_sigexp(this.Hw, this);
     },
 
     data_array: function() {
-      const sigma = this.mag_array.map(_ => this.get_sigexp(_));
-      const snr = this.mag_array.map(_ => this.get_SNR(_));
+      const sigma = this.mag_array.map(_ => ETCCore.get_sigexp(_, this));
+      const snr = this.mag_array.map(_ => ETCCore.get_SNR(_, this));
       return {
          data: [{
             x: this.mag_array,

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -23,10 +23,11 @@ function send(res, status, body, headers = {}) {
 function handler(req, res) {
   let urlPath = decodeURIComponent(req.url.split('?')[0]);
   if (urlPath === '/' || urlPath === '') urlPath = '/etc/index.html';
-  const fp = path.join(root, urlPath);
+  // Normalize and resolve the file path
+  const fp = path.resolve(root, '.' + urlPath);
 
   // Prevent path traversal
-  if (!fp.startsWith(root)) {
+  if (!fp.startsWith(root + path.sep)) {
     return send(res, 400, 'Bad Request');
   }
 

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const port = process.env.PORT || 8080;
+
+const mime = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+};
+
+function send(res, status, body, headers = {}) {
+  res.writeHead(status, Object.assign({ 'Cache-Control': 'no-cache' }, headers));
+  res.end(body);
+}
+
+function handler(req, res) {
+  let urlPath = decodeURIComponent(req.url.split('?')[0]);
+  if (urlPath === '/' || urlPath === '') urlPath = '/etc/index.html';
+  const fp = path.join(root, urlPath);
+
+  // Prevent path traversal
+  if (!fp.startsWith(root)) {
+    return send(res, 400, 'Bad Request');
+  }
+
+  fs.stat(fp, (err, stat) => {
+    if (err) return send(res, 404, 'Not Found');
+    let filePath = fp;
+    if (stat.isDirectory()) filePath = path.join(fp, 'index.html');
+    const ext = path.extname(filePath).toLowerCase();
+    const type = mime[ext] || 'application/octet-stream';
+    const stream = fs.createReadStream(filePath);
+    stream.on('error', () => send(res, 500, 'Internal Server Error'));
+    res.writeHead(200, { 'Content-Type': type, 'Cache-Control': 'no-cache' });
+    stream.pipe(res);
+  });
+}
+
+http.createServer(handler).listen(port, () => {
+  console.log(`Serving ${root} at http://localhost:${port}/ (default to /etc/index.html)`);
+});
+

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -5,49 +5,78 @@ function approxEqual(a, b, tol = 1e-6) {
   return Math.abs(a - b) <= tol;
 }
 
-function run() {
+function createBase() {
   const p = core.defaultParams();
   const Hw = core.hwFromJ(p.J, p.JH);
+  const thr0 = core.throughput(p);
+  const base = { ...p, throughput0: thr0, exptime0: p.exptime };
+  return { p: base, Hw };
+}
 
-  // Sanity: pixel scale is positive and around expected value ~0.47"/pix
+function testPixelScaleReasonable() {
+  const p = core.defaultParams();
   const scale = core.pixelScale(p.pxd, p.efl);
   assert(scale > 0, 'pixelScale should be positive');
   assert(Math.abs(scale - 0.472) < 0.02, 'pixelScale should be close to 0.472 arcsec/pix');
+}
 
-  // SNR increases with exptime
-  const thr0 = core.throughput(p);
-  const pBase = { ...p, throughput0: thr0, exptime0: p.exptime };
-  const sn1 = core.get_SNR(Hw, pBase);
-  const p2 = { ...pBase, exptime: p.exptime * 2 };
+function testSNRMonotonicWithExposure() {
+  const { p, Hw } = createBase();
+  const sn1 = core.get_SNR(Hw, p);
+  const p2 = { ...p, exptime: p.exptime * 2 };
   const sn2 = core.get_SNR(Hw, p2);
   assert(sn2 > sn1, 'SNR should increase when exposure time increases');
+}
 
-  // sigexp decreases with exptime
-  const s1 = core.get_sigexp(Hw, pBase);
+function testSigmaExpDecreasesWithExposure() {
+  const { p, Hw } = createBase();
+  const s1 = core.get_sigexp(Hw, p);
+  const p2 = { ...p, exptime: p.exptime * 2 };
   const s2 = core.get_sigexp(Hw, p2);
   assert(s2 < s1, 'Position error (sigexp) should decrease with longer exposure');
+}
 
-  // Peak photon increases when PSF gets narrower (smaller sigma)
-  const peak1 = core.peak_photon(Hw, pBase);
-  const pSharp = { ...pBase, sigpsf: p.sigpsf * 0.8 };
+function testPeakPhotonIncreasesWithSharperPSF() {
+  const { p, Hw } = createBase();
+  const peak1 = core.peak_photon(Hw, p);
+  const pSharp = { ...p, sigpsf: p.sigpsf * 0.8 };
   const peak2 = core.peak_photon(Hw, pSharp);
   assert(peak2 > peak1, 'Peak photon should increase when PSF sigma decreases');
+}
 
-  // Total photon increases with throughput increase (e.g., better mirror transmittance)
-  const tot1 = core.get_total_photon(Hw, pBase);
-  const pThr = { ...pBase, Tr_mirror: Math.min(1.0, p.Tr_mirror * 1.1) };
+function testTotalPhotonIncreasesWithThroughput() {
+  const { p, Hw } = createBase();
+  const tot1 = core.get_total_photon(Hw, p);
+  const pThr = { ...p, Tr_mirror: Math.min(1.0, p.Tr_mirror * 1.1) };
   const tot2 = core.get_total_photon(Hw, pThr);
   assert(tot2 > tot1, 'Total photon should increase with higher throughput');
+}
 
-  // Photon array sum should be > 0 and <= ideal photon count (due to finite grid)
-  const Nideal = core.get_photon(Hw, pBase);
-  const arr = core.get_photon_array(Hw, pBase);
+function testPhotonArraySumWithinIdeal() {
+  const { p, Hw } = createBase();
+  const Nideal = core.get_photon(Hw, p);
+  const arr = core.get_photon_array(Hw, p);
   let sum = 0;
   for (const row of arr) for (const e of row) sum += e;
   assert(sum > 0, 'Photon array sum should be positive');
   assert(sum <= Nideal + 1e-6, 'Photon array sum should not exceed ideal photons');
+}
 
+const tests = [
+  { name: 'Pixel scale is reasonable', fn: testPixelScaleReasonable },
+  { name: 'SNR increases with exposure time', fn: testSNRMonotonicWithExposure },
+  { name: 'Sigma_exp decreases with exposure time', fn: testSigmaExpDecreasesWithExposure },
+  { name: 'Peak photon rises with sharper PSF', fn: testPeakPhotonIncreasesWithSharperPSF },
+  { name: 'Total photon rises with throughput', fn: testTotalPhotonIncreasesWithThroughput },
+  { name: 'Photon array sum within ideal', fn: testPhotonArraySumWithinIdeal },
+];
+
+function run() {
+  for (const t of tests) t.fn();
   return true;
 }
 
-module.exports = { run };
+module.exports = {
+  run,
+  tests,
+};

--- a/tests/core.test.js
+++ b/tests/core.test.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const core = require('../etc/js/core.js');
+
+function approxEqual(a, b, tol = 1e-6) {
+  return Math.abs(a - b) <= tol;
+}
+
+function run() {
+  const p = core.defaultParams();
+  const Hw = core.hwFromJ(p.J, p.JH);
+
+  // Sanity: pixel scale is positive and around expected value ~0.47"/pix
+  const scale = core.pixelScale(p.pxd, p.efl);
+  assert(scale > 0, 'pixelScale should be positive');
+  assert(Math.abs(scale - 0.472) < 0.02, 'pixelScale should be close to 0.472 arcsec/pix');
+
+  // SNR increases with exptime
+  const thr0 = core.throughput(p);
+  const pBase = { ...p, throughput0: thr0, exptime0: p.exptime };
+  const sn1 = core.get_SNR(Hw, pBase);
+  const p2 = { ...pBase, exptime: p.exptime * 2 };
+  const sn2 = core.get_SNR(Hw, p2);
+  assert(sn2 > sn1, 'SNR should increase when exposure time increases');
+
+  // sigexp decreases with exptime
+  const s1 = core.get_sigexp(Hw, pBase);
+  const s2 = core.get_sigexp(Hw, p2);
+  assert(s2 < s1, 'Position error (sigexp) should decrease with longer exposure');
+
+  // Peak photon increases when PSF gets narrower (smaller sigma)
+  const peak1 = core.peak_photon(Hw, pBase);
+  const pSharp = { ...pBase, sigpsf: p.sigpsf * 0.8 };
+  const peak2 = core.peak_photon(Hw, pSharp);
+  assert(peak2 > peak1, 'Peak photon should increase when PSF sigma decreases');
+
+  // Total photon increases with throughput increase (e.g., better mirror transmittance)
+  const tot1 = core.get_total_photon(Hw, pBase);
+  const pThr = { ...pBase, Tr_mirror: Math.min(1.0, p.Tr_mirror * 1.1) };
+  const tot2 = core.get_total_photon(Hw, pThr);
+  assert(tot2 > tot1, 'Total photon should increase with higher throughput');
+
+  // Photon array sum should be > 0 and <= ideal photon count (due to finite grid)
+  const Nideal = core.get_photon(Hw, pBase);
+  const arr = core.get_photon_array(Hw, pBase);
+  let sum = 0;
+  for (const row of arr) for (const e of row) sum += e;
+  assert(sum > 0, 'Photon array sum should be positive');
+  assert(sum <= Nideal + 1e-6, 'Photon array sum should not exceed ideal photons');
+
+  return true;
+}
+
+module.exports = { run };

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,19 @@
+const { run } = require('./core.test.js');
+
+function main() {
+  const failures = [];
+  try {
+    run();
+    console.log('core.test.js: PASS');
+  } catch (e) {
+    console.error('core.test.js: FAIL');
+    console.error(e && e.stack ? e.stack : e);
+    failures.push(e);
+  }
+
+  if (failures.length) process.exit(1);
+  console.log('All tests passed.');
+}
+
+main();
+

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,19 +1,26 @@
-const { run } = require('./core.test.js');
+const { tests } = require('./core.test.js');
 
-function main() {
+function runSuite() {
   const failures = [];
-  try {
-    run();
-    console.log('core.test.js: PASS');
-  } catch (e) {
-    console.error('core.test.js: FAIL');
-    console.error(e && e.stack ? e.stack : e);
-    failures.push(e);
-  }
+  let passed = 0;
+  const total = tests.length;
 
+  console.log(`Running ${total} test(s)...`);
+  tests.forEach((t, i) => {
+    const label = `[${i + 1}/${total}] ${t.name}`;
+    try {
+      t.fn();
+      passed++;
+      console.log(`${label}: PASS`);
+    } catch (e) {
+      console.error(`${label}: FAIL`);
+      console.error(e && e.stack ? e.stack : e);
+      failures.push({ name: t.name, error: e });
+    }
+  });
+
+  console.log(`\nSummary: ${passed}/${total} passed, ${failures.length} failed`);
   if (failures.length) process.exit(1);
-  console.log('All tests passed.');
 }
 
-main();
-
+runSuite();


### PR DESCRIPTION
Summary

- Extract pure physics core as UMD module `ETCCore` and add Node-based tests.
- Wire UI to delegate all physics to `ETCCore`; remove `math.js` CDN.
- Add Advanced magnitude range controls (min/max sliders, step) with square slider styling and live labels.
- Add tiny static server for local UI checks.
- Expand README with local serve, tests, ETCCore usage, and UI controls.

Changes

- etc/js/core.js: ETCCore (UMD), pure functions (flux, PSF pixel integration, noise, SNR, sigma_exp, etc.)
- tests/core.test.js, tests/run-tests.js: named tests with per-case PASS/FAIL and summary
- etc/index.html: load ETCCore; remove math.js; add magnitude sliders + labels
- etc/js/jasmine-etc.js: delegate calculations to ETCCore; keep UI-only rendering
- etc/css/main.css: square slider style (outlined track + #eee fill), zero-width handle
- scripts/serve.js: tiny static server
- README.md: quick start, ETCCore usage, tests, UI controls

Testing

- node tests/run-tests.js → 6/6 passed
- Local UI via node scripts/serve.js → verified outputs/graph update and sliders work

Notes

- CDN style for Vue/Plotly is preserved; no package lock introduced
- Backward-compatible UI; no breaking API
