### PR TITLE
UI: Magnitude points + serve fix + reseed image

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Key functions (selection): `hwFromJ`, `throughput`, `pixelScale`, `totalSigma`, 
   - Magnitude range for the graph (Hw x-axis):
     - Min slider: [5, 12], step 0.1
     - Max slider: [13, 20], step 0.1
-    - Step input: sampling step in mag (default 0.5, capped to ≤60 points)
+    - Points input: number of magnitude points (min 3, max 101). The x-array contains exactly that many points, including both endpoints, with floating‑point‑safe spacing.
 - Simulated PSF image is drawn on a 15×15 canvas grid with optional asinh scaling on hover.
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Key functions (selection): `hwFromJ`, `throughput`, `pixelScale`, `totalSigma`, 
     - Max slider: [13, 20], step 0.1
     - Points input: number of magnitude points (min 3, max 101). The x-array contains exactly that many points, including both endpoints, with floating‑point‑safe spacing.
 - Simulated PSF image is drawn on a 15×15 canvas grid with optional asinh scaling on hover.
+- Simulated PSF image can be reseeded by click/tap to regenerate the noise realization.
 
 ## Tests
 

--- a/etc/index.html
+++ b/etc/index.html
@@ -138,10 +138,10 @@
                 :style="{'--min': 13, '--max': 20, '--val': mag_max}" />
             <span class="unit">{{ mag_max.toFixed(1) }} mag</span>
 
-            <label>Magnitude step</label>
-            <etc-input v-model="mag_step" precision="2"
-                min="0.01" max="10.0"></etc-input>
-            <span class="unit">mag</span>
+            <label>Magnitude points</label>
+            <etc-input v-model="mag_points" precision="0"
+                min="3" max="101"></etc-input>
+            <span class="unit">points</span>
           </div>
         </fieldset>
       </form>

--- a/etc/index.html
+++ b/etc/index.html
@@ -184,7 +184,8 @@
           <div id="psf-container"
               @touchstart="arcsinh = true" @touchend="arcsinh = false">
             <canvas id="psf-canvas" width="90" height="90"
-                @mouseover="arcsinh = true" @mouseleave="arcsinh = false">
+                @mouseover="arcsinh = true" @mouseleave="arcsinh = false"
+                @click="reseed" @touchend.prevent="reseed">
             </canvas>
           </div>
           <span class="unit"></span>

--- a/etc/js/jasmine-etc.js
+++ b/etc/js/jasmine-etc.js
@@ -101,7 +101,14 @@ let etc = new Vue({
     },
     // Reseed noise generation for simulated image
     reseed: function() {
-      // Simple evolving seed; avoids needing crypto
+      // Algorithm: update the seed with a lightweight 32-bit LCG-like step.
+      // - (seed << 5) - seed  == seed * 31 (fast multiply via shifts)
+      // - + (1 + now)        adds a time-based increment so each click/tap
+      //                      yields a different sequence without strong entropy
+      // - >>> 0              forces unsigned 32-bit wraparound to keep state
+      //                      in [0, 2^32), which our PRNG expects
+      // This keeps sequences deterministic for a given seed while making it
+      // easy to “jitter” the stream without using crypto APIs.
       const now = Date.now() >>> 0;
       this.seed = ((this.seed << 5) - this.seed + 1 + now) >>> 0;
     },

--- a/etc/js/jasmine-etc.js
+++ b/etc/js/jasmine-etc.js
@@ -121,7 +121,9 @@ let etc = new Vue({
       const u = this._mulberry32(seed);
       // Box-Muller transform using local PRNG
       const randn = () => {
-        const u1 = 1 - u();
+        let u1 = u();
+        // Ensure u1 is never 0 (which would cause log(0)); use a small epsilon if so
+        if (u1 === 0) u1 = Number.EPSILON;
         const u2 = u();
         return Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
       };

--- a/etc/js/jasmine-etc.js
+++ b/etc/js/jasmine-etc.js
@@ -67,6 +67,8 @@ let etc = new Vue({
 
     advanced: false,
     arcsinh: false,
+    // Seed for simulated image noise; change to re-generate image
+    seed: 1,
 
     pxd: 1e-5,
     efl: 4.3704,
@@ -90,10 +92,18 @@ let etc = new Vue({
   },
 
   methods: {
-    randn: () => {
-      const logu = Math.sqrt(-2.0 * Math.log(1.0 - Math.random()));
-      const cosv = Math.cos(2.0 * Math.PI * Math.random());
-      return logu * cosv;
+    // Mulberry32 PRNG factory for deterministic uniform [0,1)
+    _mulberry32: (a) => function() {
+      let t = a += 0x6D2B79F5;
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    },
+    // Reseed noise generation for simulated image
+    reseed: function() {
+      // Simple evolving seed; avoids needing crypto
+      const now = Date.now() >>> 0;
+      this.seed = ((this.seed << 5) - this.seed + 1 + now) >>> 0;
     },
 
     linear_scale: (e, M, m) => (e - m) / (M - m),
@@ -105,11 +115,19 @@ let etc = new Vue({
     add_noise: function(photon) {
       const rn = 2 * Math.pow(this.readout, 2);
       const bn = this.background * this.exptime;
-      const randn = this.randn;
       const flat = this.flat;
+      // Create a local PRNG from the current seed
+      const seed = (this.seed >>> 0) || 1;
+      const u = this._mulberry32(seed);
+      // Box-Muller transform using local PRNG
+      const randn = () => {
+        const u1 = 1 - u();
+        const u2 = u();
+        return Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
+      };
       return [...photon].map(e => e.map(function(e) {
-          const fp = 1.0 + (flat / 100) * randn();
-          return fp * e + Math.sqrt(rn + bn) * randn();
+        const fp = 1.0 + (flat / 100) * randn();
+        return fp * e + Math.sqrt(rn + bn) * randn();
       }));
     },
 
@@ -180,6 +198,8 @@ let etc = new Vue({
     },
 
     adu_array: function() {
+      // Depend on seed so reseeding triggers recomputation
+      const _seed = this.seed;
       return this.get_adu(this.add_noise(this.photon_array));
     },
 

--- a/etc/js/jasmine-etc.js
+++ b/etc/js/jasmine-etc.js
@@ -85,7 +85,8 @@ let etc = new Vue({
     // Magnitude range controls for the plot
     mag_min: 9.0,
     mag_max: 16.0,
-    mag_step: 0.5,
+    // Number of points to sample across [min, max]
+    mag_points: 15,
   },
 
   methods: {
@@ -189,11 +190,15 @@ let etc = new Vue({
     mag_array: function() {
       const lo = Math.min(this.mag_min, this.mag_max);
       const hi = Math.max(this.mag_min, this.mag_max);
-      const step = (this.mag_step > 0) ? this.mag_step : 0.5;
-      // Guard against too many points for performance
-      const maxPoints = 60;
-      const count = Math.max(2, Math.min(maxPoints, Math.floor((hi - lo) / step) + 1));
-      return Array(count).fill().map((_, i) => lo + i * step);
+      // Use P points across [lo, hi] (P in [3, 101])
+      const P = Math.max(3, Math.min(101, Math.round(this.mag_points || 3)));
+      const N = Math.max(1, P - 1);
+      const count = P;
+      const eff = (N > 0) ? (hi - lo) / N : 0;
+      const arr = Array(count).fill().map((_, i) => lo + i * eff);
+      if (arr.length > 0) arr[0] = lo;
+      if (arr.length > 1) arr[arr.length - 1] = hi;
+      return arr;
     },
 
     total_sigma: function() {

--- a/scripts/serve.js
+++ b/scripts/serve.js
@@ -22,7 +22,10 @@ function send(res, status, body, headers = {}) {
 
 function handler(req, res) {
   let urlPath = decodeURIComponent(req.url.split('?')[0]);
-  if (urlPath === '/' || urlPath === '') urlPath = '/etc/index.html';
+  // Redirect root to /etc/ to ensure relative paths resolve (css/js)
+  if (urlPath === '/' || urlPath === '') {
+    return send(res, 302, 'Found', { Location: '/etc/' });
+  }
   // Normalize and resolve the file path
   const fp = path.resolve(root, '.' + urlPath);
 
@@ -34,7 +37,14 @@ function handler(req, res) {
   fs.stat(fp, (err, stat) => {
     if (err) return send(res, 404, 'Not Found');
     let filePath = fp;
-    if (stat.isDirectory()) filePath = path.join(fp, 'index.html');
+    // For directories, enforce trailing slash and serve index.html
+    if (stat.isDirectory()) {
+      if (!urlPath.endsWith('/')) {
+        // Preserve directory path with a trailing slash
+        return send(res, 302, 'Found', { Location: urlPath + '/' });
+      }
+      filePath = path.join(fp, 'index.html');
+    }
     const ext = path.extname(filePath).toLowerCase();
     const type = mime[ext] || 'application/octet-stream';
     const stream = fs.createReadStream(filePath);
@@ -47,4 +57,3 @@ function handler(req, res) {
 http.createServer(handler).listen(port, () => {
   console.log(`Serving ${root} at http://localhost:${port}/ (default to /etc/index.html)`);
 });
-


### PR DESCRIPTION
Summary
- Switch magnitude sampling to points: user specifies number of points (3–101), evenly spanning [min, max] with FP-safe endpoints.
- Fix local server routing so / redirects to /etc/ and directories redirect to trailing-slash, ensuring css/js resolve via relative paths.
- Add reseed on click/tap for the simulated image (deterministic PRNG with seed in state).

Details
- etc/index.html: replace step input with integer Magnitude points; hook canvas click/tap to reseed.
- etc/js/jasmine-etc.js: compute mag_array from P points (P>=3) including both endpoints; seeded PRNG and recompute when seed changes.
- scripts/serve.js: add redirects for root and directories; serve index.html with correct relative base.
- README.md: document points input, serving, and reseed behavior.

Commits
- fix(serve): redirect root to /etc/ and add directory trailing-slash redirects to ensure css/js load via relative paths
- feat(ui): switch to Magnitude points control and FP-safe [min,max] sampling
- feat(ui): reseed simulated image on click/tap\n\nNotes
- Default P = 15 points.\n- Range sliders unchanged (min step 0.1 for min/max).
- Removed legacy maxPoints cap in x sampling.